### PR TITLE
Correct two typographical errors on Git usage

### DIFF
--- a/git.rmd
+++ b/git.rmd
@@ -547,7 +547,7 @@ Although you haven't realised it, you're already using branches. The default bra
 
 It's useful to create your own branches when you want to (temporarily) break away from the main stream of development. You can create a new branch with `git checkout -b <branch-name>`. Names should be in lower case letters and numbers, with `-` used to separate words. 
   
-Switch between branches with `git checkout <branch-name>`. For example, to return to the main line of development use `git branch master`. You can also use the branch switcher at the top right of the Git pane:
+Switch between branches with `git checkout <branch-name>`. For example, to return to the main line of development use `git checkout master`. You can also use the branch switcher at the top right of the Git pane:
   
 ```{r, echo = FALSE}
 bookdown::embed_png("screenshots/git-branch.png", dpi = 220)
@@ -638,7 +638,7 @@ To submit a pull request to a repo that you don't own, you first need to create 
 A fork is a _static_ copy of the repo: once you've created it, GitHub does nothing to keep it in sync with the upstream repo. This is a problem because while you're working on a pull request, changes might occur in the original repo. To keep the forked and the original repo in sync, start by telling your repo about the upstream repo:
 
 ```bash
-git remote add upstream git@github.com:<original-name>/extrafont.git
+git remote add upstream git@github.com:<original-name>/<repo>.git
 git fetch upstream
 ```
 


### PR DESCRIPTION
Running `git branch master` would try to create branch master (always will fail). Use `checkout` instead, Remove `extrafont` placeholder.

"I assign the copyright of this contribution to Hadley Wickham".
